### PR TITLE
Global imports and configuration rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 - [Why I have to use it?](#why-i-have-to-use-it)
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Plugins configuration](#plugins-configuration)
+    - [Using configuration file (same for `package.json`)](#using-configuration-file-same-for-packagejson)
+    - [Using CLI](#using-cli)
 - [Examples](#examples)
 - [Plugins](#plugins)
 - [Roadmap](#roadmap)
@@ -112,14 +115,14 @@ Commands:
 
 Options:
 
-|    Option     |           Description           |  Type   |          Default value           |
-| ------------- | ------------------------------- | ------- | -------------------------------- |
-| --version     | Show version number             | boolean |                                  |
-| --specs, -s   | Glob pattern for spec files     | string  | `"**/*.spec.js"`                 |
-| --bases, -b   | Glob pattern for baseline files | string  | `"**/*.base"`                    |
-| --help, -h    | Show help                       | boolean |                                  |
-| --plugins, -p | Plugins used for your tests     | string  | `".spec.js$:baset-baseliner-json` |
-| --options, -o | Options for plugins             | TBD     | `{}`                             |
+|    Option     |           Description           |                       Type                        |           Default value           |     |
+| ------------- | ------------------------------- | ------------------------------------------------- | --------------------------------- | --- |
+| --version     | Show version number             | boolean                                           |                                   |     |
+| --specs, -s   | Glob pattern for spec files     | string                                            | `"**/*.spec.js"`                  |     |
+| --bases, -b   | Glob pattern for baseline files | string                                            | `"**/*.base"`                     |     |
+| --help, -h    | Show help                       | boolean                                           |                                   |     |
+| --plugins, -p | Plugins used for your tests     | string \| [configuration](#plugins-configuration) | `".spec.js$:baset-baseliner-json"` |     |
+| --options, -o | Options for plugins             | TBD                                               | `{}`                              |     |
 
 In your `package.json`:
 ```JSON
@@ -162,11 +165,49 @@ In `.basetrc` or `.basetrc.json`:
 }
 ```
 
+### Plugins configuration
+The most important configuration option is `plugins`. You may configure it via command line or via configuration file or even using `baset` section in `package.json`.
+
+#### Using configuration file (same for `package.json`)
+```JSON
+{
+    "plugins": {
+        "${pattern}": "${options}"
+    }
+}
+```
+`${pattern}` - is regular expression for filename of your test files, so you may define different plugin options for different file types (e.g. using `baset-reader-ts` for `.ts` files and `baset-reader-babel` for `.js` files).  
+`${options}` - is `string` or `string[]` or `object` with following fields:
+
+|   Field     |                                                                         Description                                                                          |        Type         |    Default value     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- | -------------------- |
+| baseliner   | name or path to module, that is responsible for generating baseline                                                                                          | string **Required** | baset-baseliner-json |
+| environment | name or path to module, that mimics desired environment (e.g. browser)                                                                                       | string              | undefined            |
+| readers     | name or path to module(s), that reads and transpiles specs and source code (e.g. babel, typescript)                                                          | string[] \| string  | undefined            |
+| resolvers   | name or path to module(s), that is able to resolve specific values (e.g. [react](https://reactjs.org/) components or [pixi](http://www.pixijs.com/) sprites) | string[] \| string  | undefined            |
+| imports     | name or path to module(s), that should be imported in test context (e.g. polyfills or [reflect-metadata](https://github.com/rbuckton/reflect-metadata))      | string[] \| string  | undefined            |
+
+If `${options}` is `string`, then it used as `baseliner` name or path.  
+If `${options}` is `string[]`, then it has to follow next agreement for its content:
+```
+["-env-pluginOrPath", ..."importPaths", ..."-reader-pluginsOrPaths",  ..."-resolver-pluginsOrPaths", "-baseliner-pluginOrPath"]
+```
+Where everything except `baseliner` is optional and `...` means that several entities are allowed.
+> **NOTE:** grouping of entities is based on their names, so all plugins _MUST_ contain substring `-(env|reader|resolver|baseliner)-`, except imports (last ones don't have any naming requirements).
+
+#### Using CLI
+Just type following command in your favorite terminal:
+```
+baset -p ${pattern}:${options}
+```
+`${pattern}` - is regular expression for filename of your test files (same as in previous paragraph).  
+`${options}` - is `string[]`, where values are separated by `:` sign. This array has exactly same semantic as using `string[]` in configuration file.
+
 ## Examples
 Our [tests folder](./tests) contains projects used for end-to-end tests of `baset` package (using `baset` itself, of course), so you can use them as references for integrating baset into your workflow.
 
 ## Plugins
-There are only 2 plugins right now:  
+There are only few plugins right now:  
 1. [`baset-baseliner-json`](./packages/baset-baseliner-json) - default plugin that used for creating baseline from exported values of spec
 2. [`baset-reader-ts`](./packages/baset-reader-ts) - simple plugin that allows to write specs using [TypeScript](https://www.typescriptlang.org/)
 3. [`baset-reader-babel`](./packages/baset-reader-babel) - simple plugin that allows to write specs using [Babel](https://babeljs.io/)

--- a/packages/baset-cli/src/options/index.ts
+++ b/packages/baset-cli/src/options/index.ts
@@ -1,14 +1,61 @@
-import { utils } from 'baset-core';
+import { ITestGroupOptions, utils } from 'baset-core';
 import { Options } from 'yargs';
 
 export interface IGlobalArgs {
-    plugins: utils.IDictionary<string[]>;
+    plugins: utils.IDictionary<ITestGroupOptions>;
     // tslint:disable-next-line:no-any
     options: utils.IDictionary<any>;
 }
+export interface ITestGroupPlugins {
+    baseliner: string;
+    environment?: string;
+    readers?: string[] | string;
+    resolvers?: string[] | string;
+    imports?: string[] | string;
+}
 
-function resolveBasetPlugins(name: string) {
-    return name.startsWith('baset')
+function groupPlugins(plugins: string[]): ITestGroupOptions {
+    const firstModule = plugins.slice(0, 1)[0];
+    const environment = resolveModule((firstModule.includes('-env-') && firstModule) || undefined);
+    const firstImportIndex = Number(!!environment);
+    const firstReaderIndex = plugins.findIndex(plugin => plugin.includes('-reader-'));
+    const firstResolverIndex = plugins.findIndex(plugin => plugin.includes('-resolver-'));
+    const imports = plugins.slice(firstImportIndex, firstReaderIndex).map(resolveModule);
+    const readers = plugins.slice(firstReaderIndex, firstResolverIndex).map(resolveModule);
+    const resolvers = plugins.slice(firstResolverIndex, -1).map(resolveModule);
+    const baseliner = resolveModule(plugins.slice(-1)[0]);
+
+    return {
+        baseliner,
+        environment,
+        readers,
+        resolvers,
+        imports,
+    };
+}
+function getDefaultPlugins(plugins: ITestGroupPlugins): ITestGroupOptions {
+    return {
+        baseliner: resolveModule(plugins.baseliner),
+        environment: resolveModule(plugins.environment),
+        readers: (plugins.readers
+            ? Array.isArray(plugins.readers)
+                ? plugins.readers
+                : [plugins.readers]
+            : []).map(resolveModule),
+        resolvers: (plugins.resolvers
+            ? Array.isArray(plugins.resolvers)
+                ? plugins.resolvers
+                : [plugins.resolvers]
+            : []).map(resolveModule),
+        imports: (plugins.imports
+            ? Array.isArray(plugins.imports)
+                ? plugins.imports
+                : [plugins.imports]
+            : []).map(resolveModule),
+    };
+}
+function resolveModule<T extends string | undefined>(name: T) {
+    return (name && name.startsWith('baset'))
         ? `./node_modules/${name}`
         : name;
 }
@@ -18,27 +65,29 @@ export const options: utils.IDictionary<Options> = {
         alias: 'p',
         describe: 'Plugins used for your tests',
         default: { '.spec.js$': 'baset-baseliner-json' },
-        coerce: (plugins: string[] | { [index: string]: string[] | string }) =>
-            (plugins instanceof Array)
+        coerce: (plugins: string[] | utils.IDictionary<string[] | string | ITestGroupPlugins>) =>
+            (Array.isArray(plugins))
                 // if plugins is Array, then we get this arg from cli
-                ? plugins.reduce<{ [index: string]: string[] }>(
+                ? plugins.reduce<utils.IDictionary<ITestGroupOptions>>(
                     (result, plugin) => ({
                         ...result,
-                        // regexp for spec      // array of node modules
-                        [plugin.split(':')[0]]: plugin.split(':').slice(1).map(resolveBasetPlugins),
+                        // regexp for spec      // array of plugins
+                        [plugin.split(':')[0]]: groupPlugins(plugin.split(':').slice(1)),
                     }),
                     {})
                 // if not, then it defined in config
-                : Object.keys(plugins).reduce<{ [index: string]: string[] }>(
-                    // we have to ensure that all values are arrays
+                : Object.keys(plugins).reduce<utils.IDictionary<ITestGroupOptions>>(
+                    // we have to ensure that all values are in correct format
                     (result, key) => {
                         const plugin = plugins[key];
 
                         return {
                             ...result,
-                            [key]: (plugin instanceof Array)
-                                ? plugin.map(resolveBasetPlugins)
-                                : [resolveBasetPlugins(plugin)],
+                            [key]: (Array.isArray(plugin))
+                                ? groupPlugins(plugin)
+                                : (typeof plugin === 'string')
+                                    ? groupPlugins([plugin])
+                                    : getDefaultPlugins(plugin),
                         };
                     },
                     {}),

--- a/packages/baset-core/src/index.ts
+++ b/packages/baset-core/src/index.ts
@@ -3,6 +3,6 @@ import * as utils from './utils';
 export { AbstractBaseliner } from './abstractBaseliner';
 export { AbstractReader, AddHook, AddFileResolver } from './abstractReader';
 export { AbstractEnvironmet } from './abstractEnvironment';
-export { circularReference } from './testGroup';
+export { circularReference, ITestGroupOptions } from './testGroup';
 export { Tester } from './tester';
 export { utils };

--- a/packages/baset-core/src/testGroup.ts
+++ b/packages/baset-core/src/testGroup.ts
@@ -9,6 +9,14 @@ import { IDictionary, readFile } from './utils';
 
 export const circularReference = Symbol('circularReference');
 
+export interface ITestGroupOptions {
+    baseliner: string;
+    environment?: string;
+    readers: string[];
+    resolvers: string[];
+    imports: string[];
+}
+
 export class TestGroup {
     private baseliner: AbstractBaseliner;
     // private environemt: AbstractEnvironmet;
@@ -16,14 +24,15 @@ export class TestGroup {
     private pattern: RegExp;
     private readerChain: AbstractReader[];
     constructor(
-        pattern: string,
-        readerNames: string[],
-        baselinerName: string,
-        pluginsOptions: IDictionary<any>,
-        private environment?: string) {
+        pattern: string | RegExp,
+        private options: ITestGroupOptions,
+        private pluginsOptions: IDictionary<any>) {
         this.pattern = new RegExp(pattern);
 
-        this.readerChain = readerNames.map(readerName => {
+        const baseliner: IBaselinerConstructor = require(path.resolve(options.baseliner)).default;
+        this.baseliner = new baseliner(pluginsOptions[options.baseliner]);
+
+        this.readerChain = options.readers.map(readerName => {
             const reader: IReaderConstructor = require(path.resolve(readerName)).default;
 
             return new reader(pluginsOptions[readerName]);

--- a/packages/baset-core/src/testGroup.ts
+++ b/packages/baset-core/src/testGroup.ts
@@ -23,6 +23,7 @@ export class TestGroup {
     private references = new WeakMap<object, string>();
     private pattern: RegExp;
     private readerChain: AbstractReader[];
+    private allImports: string[];
     constructor(
         pattern: string | RegExp,
         private options: ITestGroupOptions,
@@ -37,8 +38,10 @@ export class TestGroup {
 
             return new reader(pluginsOptions[readerName]);
         });
-        const baseliner: IBaselinerConstructor = require(path.resolve(baselinerName)).default;
-        this.baseliner = new baseliner(pluginsOptions[baselinerName]);
+        this.allImports = [
+            options.environment,
+            ...options.imports,
+        ].filter((importName): importName is string  => !!importName);
     }
 
     match = (filePath: string) =>
@@ -52,9 +55,7 @@ export class TestGroup {
                 builtin: ['*'],
                 context: 'sandbox',
                 external: true,
-                import: this.environment
-                    ? [this.environment]
-                    : undefined,
+                import: this.allImports,
             },
             compiler: compiler.compile,
             sourceExtensions: compiler.extensions,

--- a/packages/baset-core/src/tester.ts
+++ b/packages/baset-core/src/tester.ts
@@ -1,14 +1,15 @@
 import path from 'path';
 import { isPrimitive } from 'util';
-import { TestGroup } from './testGroup';
+import { ITestGroupOptions, TestGroup } from './testGroup';
 import { IDictionary, isExists, readFile, unlink, writeFile } from './utils';
 
 export class Tester {
     private testGroups: TestGroup[];
 
     // tslint:disable-next-line:no-any
-    constructor(plugins: IDictionary<string[]>, pluginsOptions: IDictionary<any>) {
-        this.testGroups = this.initPlugins(plugins, pluginsOptions);
+    constructor(plugins: IDictionary<ITestGroupOptions>, pluginsOptions: IDictionary<any>) {
+        this.testGroups = Object.keys(plugins)
+            .map(key => new TestGroup(key, plugins[key], pluginsOptions));
     }
 
     test(specs: string[], baselines: string[]) {
@@ -45,15 +46,4 @@ export class Tester {
 
         return filePath;
     }
-
-    // tslint:disable-next-line:no-any
-    private initPlugins = (plugins: IDictionary<string[]>, pluginsOptions: IDictionary<any>) =>
-        Object.keys(plugins).map(key => {
-            const firstModule = plugins[key].slice(0, 1)[0];
-            const envModule = firstModule.includes('-env-') && firstModule;
-            const baseliner = plugins[key].slice(-1)[0];
-            const readers = plugins[key].slice(Number(!!envModule), -1);
-
-            return new TestGroup(key, readers, baseliner, pluginsOptions, envModule || undefined);
-        })
 }

--- a/tests/typescript-project/.basetrc
+++ b/tests/typescript-project/.basetrc
@@ -3,6 +3,10 @@
     "bases": "**/*.base",
     "plugins": {
         ".spec.js$": "baset-baseliner-json",
-        ".spec.ts$": ["baset-reader-ts", "baset-baseliner-json"]
+        ".spec.ts$": {
+            "readers": "baset-reader-ts",
+            "baseliner": "baset-baseliner-json",
+            "imports": "./polyfill"
+        }
     }
 }

--- a/tests/typescript-project/lib/someCoolClass.ts
+++ b/tests/typescript-project/lib/someCoolClass.ts
@@ -1,7 +1,13 @@
+function logParamTypes(target: any, key: string) {
+    const types = Reflect.getMetadata('design:paramtypes', target, key);
+    const s = types.map((a: any) => a.name).join();
+}
+
 export class SomeCoolClass {
     private a = 1000;
     private b = 300;
 
+    @logParamTypes
     getSum() {
         return this.a + this.b;
     }

--- a/tests/typescript-project/package.json
+++ b/tests/typescript-project/package.json
@@ -10,6 +10,10 @@
     },
     "author": "",
     "license": "MIT",
+    "dependencies": {
+        "tslib": "^1.9.0",
+        "reflect-metadata": "^0.1.12"
+    },
     "devDependencies": {
         "baset": "^0.7.4",
         "baset-baseliner-json": "^0.7.4",

--- a/tests/typescript-project/polyfill.ts
+++ b/tests/typescript-project/polyfill.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata';

--- a/tests/typescript-project/tsconfig.json
+++ b/tests/typescript-project/tsconfig.json
@@ -11,8 +11,13 @@
         "noImplicitThis": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
+        "importHelpers": true,
         "moduleResolution": "node",
         "baseUrl": ".",
+        "lib": [
+            "dom",
+            "es7"
+        ],
         "paths": {
             "*": [
                 "node_modules/*",
@@ -22,5 +27,9 @@
         },
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true
-    }
+    },
+    "include": [
+        "lib/**/*",
+        "/*.ts"
+    ]
 }


### PR DESCRIPTION
### Description of Change
While working on #41, I've found that problem isn't in compiler options of `typescript` but in its `include` option which adds all global namespaces (e.g. `reflect-metadata`) from included files to compiler context. So solution for this issue is adding an option to include some files/modules/packages to context of each test.
This new option has shown some existing problems with baset configuration, so a little refactoring of this part also included here.

### Pull Request check-list
- [x] Does the linter pass?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?
